### PR TITLE
Fix <script> validation

### DIFF
--- a/lsp-vue.el
+++ b/lsp-vue.el
@@ -101,6 +101,12 @@
 
 (defcustom vetur.validation.style
   t
+  "Validate css/scss/less in <style>"
+  :group 'vetur
+  :type 'boolean)
+
+(defcustom vetur.validation.script
+  t
   "Validate js/ts in <script>"
   :group 'vetur
   :type 'boolean)


### PR DESCRIPTION
According to https://vuejs.github.io/vetur/linting-error.html#error-checking
there are 3 different options for validation: template/style/script.
But only 2 of them were exposed as a customizable item (and `style`
had an error in the docstring).